### PR TITLE
fix: hiclor icons not fount by add patches

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.6.1+dfsg-5deepin2) unstable; urgency=medium
+
+  * Add Make-sure-hicolor-searched-before-dashfallbacks.patch.
+
+ -- Mike Chen <chenke@deepin.org>  Wed, 17 Jan 2024 10:17:49 +0800
+
 qt6-base (6.6.1+dfsg-5deepin1) unstable; urgency=medium
 
   * Add Allow-QPalettePrivate-to-be-used-outside-of-qpalette-cpp.patch.

--- a/debian/patches/Make-sure-hicolor-searched-before-dashfallbacks.patch
+++ b/debian/patches/Make-sure-hicolor-searched-before-dashfallbacks.patch
@@ -1,0 +1,204 @@
+diff --git a/src/gui/image/qiconloader.cpp b/src/gui/image/qiconloader.cpp
+index 876c3e0f..982b9a26 100644
+--- a/src/gui/image/qiconloader.cpp
++++ b/src/gui/image/qiconloader.cpp
+@@ -392,6 +392,17 @@ QIconTheme::QIconTheme(const QString &themeName)
+                     dirInfo.maxSize = indexReader.value(directoryKey + "/MaxSize"_L1, size).toInt();
+ 
+                     dirInfo.scale = indexReader.value(directoryKey + "/Scale"_L1, 1).toInt();
++
++                    const QString context = indexReader.value(directoryKey + "/Context"_L1).toString();
++                    dirInfo.context = [context]() {
++                        if (context == "Applications"_L1)
++                            return QIconDirInfo::Applications;
++                        else if (context == "MimeTypes"_L1)
++                            return QIconDirInfo::MimeTypes;
++                        else
++                            return QIconDirInfo::UnknownContext;
++                    }();
++
+                     m_keyList.append(dirInfo);
+                 }
+             }
+@@ -430,7 +441,8 @@ QDebug operator<<(QDebug debug, const std::unique_ptr<QIconLoaderEngineEntry> &e
+ 
+ QThemeIconInfo QIconLoader::findIconHelper(const QString &themeName,
+                                            const QString &iconName,
+-                                           QStringList &visited) const
++                                           QStringList &visited,
++                                           DashRule rule) const
+ {
+     qCDebug(lcIconLoader) << "Finding icon" << iconName << "in theme" << themeName
+                           << "skipping" << visited;
+@@ -453,9 +465,10 @@ QThemeIconInfo QIconLoader::findIconHelper(const QString &themeName,
+     const QStringList contentDirs = theme.contentDirs();
+ 
+     QStringView iconNameFallback(iconName);
++    bool searchingGenericFallback = m_iconName.length() > iconName.length();
+ 
+     // Iterate through all icon's fallbacks in current theme
+-    while (info.entries.empty()) {
++    if (info.entries.empty()) {
+         const QString svgIconName = iconNameFallback + ".svg"_L1;
+         const QString pngIconName = iconNameFallback + ".png"_L1;
+ 
+@@ -487,6 +500,11 @@ QThemeIconInfo QIconLoader::findIconHelper(const QString &themeName,
+             QString contentDir = contentDirs.at(i) + u'/';
+             for (int j = 0; j < subDirs.size() ; ++j) {
+                 const QIconDirInfo &dirInfo = subDirs.at(j);
++                if (searchingGenericFallback &&
++                        (dirInfo.context == QIconDirInfo::Applications ||
++                         dirInfo.context == QIconDirInfo::MimeTypes))
++                    continue;
++
+                 const QString subDir = contentDir + dirInfo.path + u'/';
+                 const QString pngPath = subDir + pngIconName;
+                 if (QFile::exists(pngPath)) {
+@@ -510,15 +528,7 @@ QThemeIconInfo QIconLoader::findIconHelper(const QString &themeName,
+ 
+         if (!info.entries.empty()) {
+             info.iconName = iconNameFallback.toString();
+-            break;
+         }
+-
+-        // If it's possible - find next fallback for the icon
+-        const int indexOfDash = iconNameFallback.lastIndexOf(u'-');
+-        if (indexOfDash == -1)
+-            break;
+-
+-        iconNameFallback.truncate(indexOfDash);
+     }
+ 
+     if (info.entries.empty()) {
+@@ -533,13 +543,25 @@ QThemeIconInfo QIconLoader::findIconHelper(const QString &themeName,
+             const QString parentTheme = parents.at(i).trimmed();
+ 
+             if (!visited.contains(parentTheme)) // guard against recursion
+-                info = findIconHelper(parentTheme, iconName, visited);
++                info = findIconHelper(parentTheme, iconName, visited, QIconLoader::NoFallBack);
+ 
+             if (!info.entries.empty()) // success
+                 break;
+         }
+     }
+ 
++    if (rule == QIconLoader::FallBack && info.entries.empty()) {
++        // If it's possible - find next fallback for the icon
++        const int indexOfDash = iconNameFallback.lastIndexOf(u'-');
++        if (indexOfDash != -1) {
++            qCDebug(lcIconLoader) << "Did not find matching icons in all themes;"
++                                  << "trying dash fallback";
++            iconNameFallback.truncate(indexOfDash);
++            QStringList _visited;
++            info = findIconHelper(themeName, iconNameFallback.toString(), _visited, QIconLoader::FallBack);
++        }
++    }
++
+     return info;
+ }
+ 
+@@ -587,13 +609,14 @@ QThemeIconInfo QIconLoader::loadIcon(const QString &name) const
+ {
+     qCDebug(lcIconLoader) << "Loading icon" << name;
+ 
++    m_iconName = name;
+     QThemeIconInfo iconInfo;
+     QStringList visitedThemes;
+     if (!themeName().isEmpty())
+-        iconInfo = findIconHelper(themeName(), name, visitedThemes);
++        iconInfo = findIconHelper(themeName(), name, visitedThemes, QIconLoader::FallBack);
+ 
+     if (iconInfo.entries.empty() && !fallbackThemeName().isEmpty())
+-        iconInfo = findIconHelper(fallbackThemeName(), name, visitedThemes);
++        iconInfo = findIconHelper(fallbackThemeName(), name, visitedThemes, QIconLoader::FallBack);
+ 
+     if (iconInfo.entries.empty())
+         iconInfo = lookupFallbackIcon(name);
+@@ -626,13 +649,23 @@ QIconEngine *QIconLoader::iconEngine(const QString &iconName) const
+ {
+     qCDebug(lcIconLoader) << "Resolving icon engine for icon" << iconName;
+ 
+-    auto *platformTheme = QGuiApplicationPrivate::platformTheme();
+     std::unique_ptr<QIconEngine> iconEngine;
+-    if (!hasUserTheme() && platformTheme)
+-        iconEngine.reset(platformTheme->createIconEngine(iconName));
+-    if (!iconEngine || iconEngine->isNull()) {
++    if (hasUserTheme())
+         iconEngine.reset(new QIconLoaderEngine(iconName));
++    if (!iconEngine || iconEngine->isNull()) {
++        qCDebug(lcIconLoader) << "Icon is not available from theme or fallback theme.";
++        if (auto *platformTheme = QGuiApplicationPrivate::platformTheme()) {
++            qCDebug(lcIconLoader) << "Trying platform engine.";
++            std::unique_ptr<QIconEngine> themeEngine(platformTheme->createIconEngine(iconName));
++            if (themeEngine && !themeEngine->isNull()) {
++                iconEngine = std::move(themeEngine);
++                qCDebug(lcIconLoader) << "Icon provided by platform engine.";
++            }
++        }
+     }
++    // We need to maintain the invariant that the QIcon has a valid engine
++    if (!iconEngine)
++        iconEngine.reset(new QIconLoaderEngine(iconName));
+ 
+     qCDebug(lcIconLoader) << "Resulting engine" << iconEngine.get();
+     return iconEngine.release();
+@@ -845,7 +878,7 @@ QSize QIconLoaderEngine::actualSize(const QSize &size, QIcon::Mode mode,
+         } else if (dir.type == QIconDirInfo::Fallback) {
+             return QIcon(entry->filename).actualSize(size, mode, state);
+         } else {
+-            int result = qMin<int>(dir.size, qMin(size.width(), size.height()));
++            int result = qMin<int>(dir.size * dir.scale, qMin(size.width(), size.height()));
+             return QSize(result, result);
+         }
+     }
+diff --git a/src/gui/image/qiconloader_p.h b/src/gui/image/qiconloader_p.h
+index 816fb770..3cfa9381 100644
+--- a/src/gui/image/qiconloader_p.h
++++ b/src/gui/image/qiconloader_p.h
+@@ -38,6 +38,7 @@ class QIconLoader;
+ struct QIconDirInfo
+ {
+     enum Type { Fixed, Scalable, Threshold, Fallback };
++    enum Context { UnknownContext, Applications, MimeTypes };
+     QIconDirInfo(const QString &_path = QString()) :
+             path(_path),
+             size(0),
+@@ -45,7 +46,8 @@ struct QIconDirInfo
+             minSize(0),
+             threshold(0),
+             scale(1),
+-            type(Threshold) {}
++            type(Threshold),
++            context(UnknownContext) {}
+     QString path;
+     short size;
+     short maxSize;
+@@ -53,6 +55,7 @@ struct QIconDirInfo
+     short threshold;
+     short scale;
+     Type type;
++    Context context;
+ };
+ Q_DECLARE_TYPEINFO(QIconDirInfo, Q_RELOCATABLE_TYPE);
+ 
+@@ -184,9 +187,11 @@ public:
+     QIconEngine *iconEngine(const QString &iconName) const;
+ 
+ private:
++    enum DashRule { FallBack, NoFallBack };
+     QThemeIconInfo findIconHelper(const QString &themeName,
+                                   const QString &iconName,
+-                                  QStringList &visited) const;
++                                  QStringList &visited,
++                                  DashRule rule) const;
+     QThemeIconInfo lookupFallbackIcon(const QString &iconName) const;
+ 
+     uint m_themeKey;
+@@ -199,6 +204,7 @@ private:
+     mutable QStringList m_iconDirs;
+     mutable QHash <QString, QIconTheme> themeList;
+     mutable QStringList m_fallbackDirs;
++    mutable QString m_iconName;
+ };
+ 
+ QT_END_NAMESPACE

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -16,3 +16,6 @@ enable_skip_plugins.patch
 armel-noyield.patch
 
 deepin-Allow-QPalettePrivate-to-be-used-outside-of-qpalette-cpp.patch
+
+# https://codereview.qt-project.org/c/qt/qtbase/+/530805
+Make-sure-hicolor-searched-before-dashfallbacks.patch


### PR DESCRIPTION
Make sure hicolor is searched before dash fallbacks 
TODO: revert me if upstream pr merged!
https://codereview.qt-project.org/c/qt/qtbase/+/530805

Issue: https://github.com/linuxdeepin/developer-center/issues/6862