### PR TITLE
Add QT_FORCE_OPENGL_TYPE

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.6.1+dfsg-5deepin5) unstable; urgency=medium
+
+ * feat: Add QT_FORCE_OPENGL_TYPE
+
+ -- Lu YaNing <luyaning@uniontech.org>  Wed, 18 Sep 2024 14:05:16 +0800
+
 qt6-base (6.6.1+dfsg-5deepin4) unstable; urgency=medium
 
   * fix: Ensure that libzstd targets are promoted to global i

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.6.1+dfsg-5deepin4) unstable; urgency=medium
+
+  * fix: Ensure that libzstd targets are promoted to global i
+
+ -- hudeng <hudeng@deepin.org>  Mon, 16 Sep 2024 00:06:35 +0800
+
 qt6-base (6.6.1+dfsg-5deepin3) unstable; urgency=medium
 
   * feat: Add QT_IM_MODULES env to allows specify multi IM key

--- a/debian/patches/CMake-Fix-Threads-Threads-global-target-promotion-is.patch
+++ b/debian/patches/CMake-Fix-Threads-Threads-global-target-promotion-is.patch
@@ -1,0 +1,29 @@
+From b225b545a01ed2f0e12d090b840fbad0381fbf79 Mon Sep 17 00:00:00 2001
+From: hudeng <hudeng@deepin.org>
+Date: Mon, 16 Sep 2024 12:49:59 +0800
+Subject: [PATCH] CMake: Fix Threads::Threads global target promotion issue
+
+---
+ configure.cmake | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/configure.cmake b/configure.cmake
+index 0446bc1c..0b0484bb 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -118,6 +118,12 @@ qt_find_package(WrapZSTD 1.3
+     MODULE_NAME global
+     QMAKE_LIB zstd
+ )
++# Threads::Threads might be brought in via a top-level CMakeLists.txt find_package dependency
++# in which case if the system WebpConfig.cmake depends Threads, it shouldn't try to promote it to
++# global to avoid a 'global promotion of a target in a different subdirectory' error.
++if(TARGET Threads::Threads)
++    qt_internal_disable_find_package_global_promotion(Threads::Threads)
++endif()
+ qt_find_package(WrapDBus1 1.2 PROVIDED_TARGETS dbus-1 MODULE_NAME global QMAKE_LIB dbus)
+ qt_find_package(Libudev PROVIDED_TARGETS PkgConfig::Libudev MODULE_NAME global QMAKE_LIB libudev)
+ qt_find_package(LTTngUST PROVIDED_TARGETS LTTng::UST MODULE_NAME core QMAKE_LIB lttng-ust)
+-- 
+2.45.2
+

--- a/debian/patches/QT_FORCE_OPENGL_TYPE.patch
+++ b/debian/patches/QT_FORCE_OPENGL_TYPE.patch
@@ -1,0 +1,35 @@
+Author: Lu YaNing <luyaning@uniontech.com>
+Date:   Thur, 11 Sep 2024 13:50:02 +0800
+Subject: Add QT_FORCE_OPENGL_TYPE
+
+
+Index: qt6-base/src/gui/kernel/qguiapplication.cpp
+===================================================================
+--- qt6-base.orig/src/gui/kernel/qguiapplication.cpp
++++ qt6-base/src/gui/kernel/qguiapplication.cpp
+@@ -46,6 +46,7 @@
+ #include <QtGui/private/qstylehints_p.h>
+ #include <QtGui/qinputmethod.h>
+ #include <QtGui/qpixmapcache.h>
++#include <QtGui/QSurfaceFormat>
+ #include <qpa/qplatforminputcontext.h>
+ #include <qpa/qplatforminputcontext_p.h>
+ 
+@@ -1435,6 +1436,17 @@ void QGuiApplicationPrivate::createPlatf
+     // Load the platform integration
+     QString platformPluginPath = QString::fromLocal8Bit(qgetenv("QT_QPA_PLATFORM_PLUGIN_PATH"));
+ 
++    QString renderType = QString::fromLocal8Bit(qgetenv("QT_FORCE_OPENGL_TYPE"));
++    if (!renderType.isEmpty()) {
++        QSurfaceFormat format = QSurfaceFormat::defaultFormat();
++
++        if (renderType == "OpenGL"_L1)
++            format.setRenderableType(QSurfaceFormat::OpenGL);
++        else if (renderType == "OpenGLES"_L1)
++            format.setRenderableType(QSurfaceFormat::OpenGLES);
++
++        QSurfaceFormat::setDefaultFormat(format);
++    }
+ 
+     QByteArray platformName;
+ #ifdef QT_QPA_DEFAULT_PLATFORM_NAME

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,3 +22,6 @@ Make-sure-hicolor-searched-before-dashfallbacks.patch
 
 # https://codereview.qt-project.org/c/qt/qtbase/+/526124
 add_QT_IM_MODULES_env_to_allows_multi_IM_key.patch
+upstream_Ensure-that-libzstd-targets-are-promoted-to-global-i.patch
+upstream_Prefer-using-the-non-suffixed-libzstd-over-static-on.patch
+CMake-Fix-Threads-Threads-global-target-promotion-is.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ add_QT_IM_MODULES_env_to_allows_multi_IM_key.patch
 upstream_Ensure-that-libzstd-targets-are-promoted-to-global-i.patch
 upstream_Prefer-using-the-non-suffixed-libzstd-over-static-on.patch
 CMake-Fix-Threads-Threads-global-target-promotion-is.patch
+QT_FORCE_OPENGL_TYPE.patch

--- a/debian/patches/upstream_Ensure-that-libzstd-targets-are-promoted-to-global-i.patch
+++ b/debian/patches/upstream_Ensure-that-libzstd-targets-are-promoted-to-global-i.patch
@@ -1,0 +1,39 @@
+From 3073b9c4dec5e5877363794bf81cbd4b84fdb9ee Mon Sep 17 00:00:00 2001
+From: Alexey Edelev <alexey.edelev@qt.io>
+Date: Tue, 28 May 2024 16:36:41 +0200
+Subject: [PATCH] Ensure that libzstd targets are promoted to global if they
+ were found
+
+Promote all internal zstd targets if they were found by WrapZSTD to
+global using PROVIDED_TARGETS mechanism.
+
+Amends 7d9d1220f367d9275dfaa7ce12e89b0a9f4c1978
+
+Task-numer: QTBUG-119469
+Change-Id: I15ec484304f7bf2b3ee2a533d2badb3bb7797863
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ configure.cmake | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+Index: qt6-base/configure.cmake
+===================================================================
+--- qt6-base.orig/configure.cmake
++++ qt6-base/configure.cmake
+@@ -109,7 +109,15 @@ SSL_free(SSL_new(0));
+ }
+ ")
+ 
+-qt_find_package(WrapZSTD 1.3 PROVIDED_TARGETS WrapZSTD::WrapZSTD MODULE_NAME global QMAKE_LIB zstd)
++qt_find_package(WrapZSTD 1.3
++    PROVIDED_TARGETS
++        WrapZSTD::WrapZSTD
++        zstd::libzstd
++        zstd::libzstd_static
++        zstd::libzstd_shared
++    MODULE_NAME global
++    QMAKE_LIB zstd
++)
+ qt_find_package(WrapDBus1 1.2 PROVIDED_TARGETS dbus-1 MODULE_NAME global QMAKE_LIB dbus)
+ qt_find_package(Libudev PROVIDED_TARGETS PkgConfig::Libudev MODULE_NAME global QMAKE_LIB libudev)
+ qt_find_package(LTTngUST PROVIDED_TARGETS LTTng::UST MODULE_NAME core QMAKE_LIB lttng-ust)

--- a/debian/patches/upstream_Prefer-using-the-non-suffixed-libzstd-over-static-on.patch
+++ b/debian/patches/upstream_Prefer-using-the-non-suffixed-libzstd-over-static-on.patch
@@ -1,0 +1,39 @@
+From 7d9d1220f367d9275dfaa7ce12e89b0a9f4c1978 Mon Sep 17 00:00:00 2001
+From: Alexey Edelev <alexey.edelev@qt.io>
+Date: Mon, 27 May 2024 11:09:05 +0200
+Subject: [PATCH] Prefer using the non-suffixed libzstd over static one
+
+Recent zstd versions provide the libstd target but not only libzstd_shared
+or libzstd_static. Attempt to use it as the WrapZSTD::WrapZSTD counterpart
+if the target exists.
+
+Task-number: QTBUG-119469
+Change-Id: I47916bfa6f10883d099184a497800277c8026b14
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ cmake/FindWrapZSTD.cmake | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+Index: qt6-base/cmake/FindWrapZSTD.cmake
+===================================================================
+--- qt6-base.orig/cmake/FindWrapZSTD.cmake
++++ qt6-base/cmake/FindWrapZSTD.cmake
+@@ -25,14 +25,17 @@ find_package(zstd CONFIG QUIET)
+ 
+ include(FindPackageHandleStandardArgs)
+ 
+-if(TARGET zstd::libzstd_static OR TARGET zstd::libzstd_shared)
++if(TARGET zstd::libzstd_static OR TARGET zstd::libzstd_shared OR TARGET zstd::libzstd)
+     find_package_handle_standard_args(WrapZSTD
+                                       REQUIRED_VARS zstd_VERSION VERSION_VAR zstd_VERSION)
+     if(TARGET zstd::libzstd_shared)
+         set(zstdtargetsuffix "_shared")
++    elseif(TARGET zstd::libzstd)
++        set(zstdtargetsuffix "")
+     else()
+         set(zstdtargetsuffix "_static")
+     endif()
++
+     if(NOT TARGET WrapZSTD::WrapZSTD)
+         add_library(WrapZSTD::WrapZSTD INTERFACE IMPORTED)
+         set_target_properties(WrapZSTD::WrapZSTD PROPERTIES


### PR DESCRIPTION
The user can set QT_FORCE_OPENGL_TYPE to OpenGL or OpenGLES. The default value is OpenGL. No longer need to reconfigure the compilation parameter es2 opengl.