### PR TITLE
Fix CVE-2025-5455 in Qt 6.8: Handle missing charset value in qDecodeD…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+qt6-base (6.8.0+dfsg-0deepin7.1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+  * fix: Handle missing charset value in qDecodeDataUrl to avoid assertion
+    -- CVE-2025-5455_qDecodeDataUrl_FixMalformedCharsetHandling.patch
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 12 Jun 2025 17:08:43 +0800
+
 qt6-base (6.8.0+dfsg-0deepin7) unstable; urgency=medium
 
   * Revert "Add Give-the-popup-window-focus.patch"

--- a/debian/patches/CVE-2025-5455_qDecodeDataUrl_FixMalformedCharsetHandling.patch
+++ b/debian/patches/CVE-2025-5455_qDecodeDataUrl_FixMalformedCharsetHandling.patch
@@ -1,0 +1,47 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Thu May 04 16:20:24 2025
+Subject:Handle missing charset value in qDecodeDataUrl to avoid assertion
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/642006
+
+Index: qt6-base/src/corelib/io/qdataurl.cpp
+===================================================================
+--- qt6-base.orig/src/corelib/io/qdataurl.cpp
++++ qt6-base/src/corelib/io/qdataurl.cpp
+@@ -47,10 +47,10 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const
+         QLatin1StringView textPlain;
+         constexpr auto charset = "charset"_L1;
+         if (QLatin1StringView{data}.startsWith(charset, Qt::CaseInsensitive)) {
+-            qsizetype i = charset.size();
+-            while (data.at(i) == ' ')
+-                ++i;
+-            if (data.at(i) == '=')
++            QByteArrayView copy = data.sliced(charset.size());
++            while (copy.startsWith(' '))
++                copy = copy.sliced(1);
++            if (copy.startsWith('='))
+                 textPlain = "text/plain;"_L1;
+         }
+ 
+Index: qt6-base/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+===================================================================
+--- qt6-base.orig/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
++++ qt6-base/tests/auto/corelib/io/qdataurl/tst_qdataurl.cpp
+@@ -1,4 +1,4 @@
+-// Copyright (C) 2016 The Qt Company Ltd.
++dpk -// Copyright (C) 2016 The Qt Company Ltd.
+ // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR GPL-3.0-only
+ 
+ #include "private/qdataurl_p.h"
+@@ -34,8 +34,11 @@ void tst_QDataUrl::decode_data()
+         "text/plain"_L1, QByteArray::fromPercentEncoding("%E2%88%9A"));
+     row("everythingIsCaseInsensitive", "Data:texT/PlaiN;charSet=iSo-8859-1;Base64,SGVsbG8=", true,
+         "texT/PlaiN;charSet=iSo-8859-1"_L1, QByteArrayLiteral("Hello"));
+-}
++    row("prematureCharsetEnd", "data:charset,", true,
++        "charset", ""); // nonsense result, but don't crash  
+ 
++}
++    
+ void tst_QDataUrl::decode()
+ {
+     QFETCH(const QString, input);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,3 +27,4 @@ enable_skip_plugins.patch
 CMake-Fix-Threads-Threads-global-target-promotion-is.patch
 QT_FORCE_OPENGL_TYPE.patch
 fix-QApplciation-with-a-QML-popupWindow.patch
+CVE-2025-5455_qDecodeDataUrl_FixMalformedCharsetHandling.patch


### PR DESCRIPTION
…ataUrl to avoid assertion

The private function qDecodeDataUrl() in QtCore could trigger an assertion failure when parsing malformed data URLs with a "charset" parameter that lacks a value (e.g., "data:charset,"). This issue affects Qt versions up to 6.8.

This patch applies the fix specifically to Qt 6.8, preventing a denial of service scenario when built with assertions enabled.

Issue: CVE-2025-5455
Fixed in upstream version: Qt 6.8