### PR TITLE
QLabel: Reset link hover state when mouse leaves the label

### DIFF
--- a/src/widgets/widgets/qlabel.cpp
+++ b/src/widgets/widgets/qlabel.cpp
@@ -1389,6 +1389,20 @@ void QLabel::changeEvent(QEvent *ev)
 }
 
 /*!
+  \reimp
+*/
+void QLabel::leaveEvent(QEvent *ev)
+{
+    Q_D(QLabel);
+    if (d->isTextLabel && d->control) {
+        // Clear the link hover state in the text control
+        QMouseEvent e(QEvent::MouseMove, QPointF(-1, -1), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+        d->sendControlEvent(&e);
+    }
+    QFrame::leaveEvent(ev);
+}
+
+/*!
     \property QLabel::scaledContents
     \brief whether the label will scale its contents to fill all
     available space.

--- a/src/widgets/widgets/qlabel.h
+++ b/src/widgets/widgets/qlabel.h
@@ -116,6 +116,7 @@ protected:
     void keyPressEvent(QKeyEvent *ev) override;
     void paintEvent(QPaintEvent *) override;
     void changeEvent(QEvent *) override;
+    void leaveEvent(QEvent *) override;
     void mousePressEvent(QMouseEvent *ev) override;
     void mouseMoveEvent(QMouseEvent *ev) override;
     void mouseReleaseEvent(QMouseEvent *ev) override;


### PR DESCRIPTION
When the mouse leaves a QLabel containing rich text with links, the internal QWidgetTextControl was not notified. This caused the highlightedAnchor state to remain cached. If the mouse later re-entered the label directly over the same link, QWidgetTextControl would see that the anchor hadn't changed and would not emit the linkHovered signal.

This fix adds a leaveEvent handler that sends a synthetic mouse move event with an invalid position (-1, -1) to the text control, forcing it to clear the hover state and emit linkHovered with an empty string.

Fixes: QTBUG-143965