### PR TITLE
fix: add multi-seat event support for QWindowSystemInterface key events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.8.0+dfsg-0deepin24) unstable; urgency=medium
+
+  * fix: add multi-seat event support for QWindowSystemInterface key events
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Mon, 15 Jun 2026 15:28:47 +0800
+
 qt6-base (6.8.0+dfsg-0deepin23) unstable; urgency=medium
 
   * fix: QLabel reset link hover state when mouse leaves

--- a/debian/patches/qt6-base-add-multi-seat-event.patch
+++ b/debian/patches/qt6-base-add-multi-seat-event.patch
@@ -1,4 +1,4 @@
-Author: Tian Shilin<tianshilin@uniontech.com>
+Author: Tian Shilin <tianshilin@uniontech.com>
 Date:   Mon Jun 15 15:26:49 2026
 Subject: add multi-seat event support for QWindowSystemInterface key events
 

--- a/debian/patches/qt6-base-add-multi-seat-event.patch
+++ b/debian/patches/qt6-base-add-multi-seat-event.patch
@@ -1,0 +1,43 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Mon Jun 15 15:26:49 2026
+Subject: add multi-seat event support for QWindowSystemInterface key events
+
+
+---
+
+Index: qt6-base/src/gui/kernel/qguiapplication.cpp
+===================================================================
+--- qt6-base.orig/src/gui/kernel/qguiapplication.cpp
++++ qt6-base/src/gui/kernel/qguiapplication.cpp
+@@ -2596,7 +2596,7 @@ void QGuiApplicationPrivate::processKeyE
+ 
+     QKeyEvent ev(e->keyType, e->key, e->modifiers,
+                  e->nativeScanCode, e->nativeVirtualKey, e->nativeModifiers,
+-                 e->unicode, e->repeat, e->repeatCount);
++                 e->unicode, e->repeat, e->repeatCount, e->device);
+     ev.setTimestamp(e->timestamp);
+ 
+     const auto *activePopup = activePopupWindow();
+Index: qt6-base/src/gui/kernel/qwindowsysteminterface.cpp
+===================================================================
+--- qt6-base.orig/src/gui/kernel/qwindowsysteminterface.cpp
++++ qt6-base/src/gui/kernel/qwindowsysteminterface.cpp
+@@ -495,6 +495,18 @@ bool QWindowSystemInterface::handleExten
+         timestamp, type, key, modifiers, nativeScanCode, nativeVirtualKey, nativeModifiers, text, autorep, count);
+ }
+ 
++bool QWindowSystemInterface::handleExtendedKeyEvent(QWindow *window, ulong timestamp, const QInputDevice *device,
++                                                  QEvent::Type type, int key, Qt::KeyboardModifiers modifiers,
++                                                  quint32 nativeScanCode, quint32 nativeVirtualKey,
++                                                  quint32 nativeModifiers,
++                                                  const QString& text, bool autorep,
++                                                  ushort count)
++{
++    return handleWindowSystemEvent<QWindowSystemInterfacePrivate::KeyEvent>(window,
++        timestamp, type, key, modifiers, nativeScanCode, nativeVirtualKey, 
++        nativeModifiers, text, autorep, count, device);
++}
++
+ bool QWindowSystemInterface::handleWheelEvent(QWindow *window, const QPointF &local, const QPointF &global, QPoint pixelDelta, QPoint angleDelta, Qt::KeyboardModifiers mods, Qt::ScrollPhase phase, Qt::MouseEventSource source)
+ {
+     unsigned long time = QWindowSystemInterfacePrivate::eventTime.elapsed();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -43,3 +43,4 @@ Check-exactly-the-first-bit-of-XdndStatus-flags-in-QXcbDrag.patch
 fix-xcb-clear-stale-internal-state-when-setting-up-slave-devices.patch
 fix-xcb-Handle-DEVICE_ENABLED-in-XI2-hierarchy-events.patch
 fix-QLabel-Reset-link-hover-state.patch
+qt6-base-add-multi-seat-event.patch


### PR DESCRIPTION
Log: QWindowSystemInterface::handleExtendedKeyEvent lacked an overload that accepts a QInputDevice pointer, preventing callers from specifying which seat's keyboard generated the event. Add the overload and propagate the device into the KeyEvent so that QGuiApplication passes it through to QKeyEvent construction, enabling correct device identity in multi-seat scenarios.