### PR TITLE
fix(xml): change default QDom invalid data policy（CVE-2026-15037）

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qt6-base (6.8.0+dfsg-0deepin25) unstable; urgency=medium
+
+  * Update patch: change QDom default InvalidDataPolicy to
+    ReturnNullNode (CVE-2026-15037, QTBUG-147717).
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Mon, 13 Jul 2026 10:51:47 +0800
+
 qt6-base (6.8.0+dfsg-0deepin24) unstable; urgency=medium
 
   * fix: add multi-seat event support for QWindowSystemInterface key events

--- a/debian/patches/QDom-Change-default-InvalidDataPolicy-to-ReturnNullNode.patch
+++ b/debian/patches/QDom-Change-default-InvalidDataPolicy-to-ReturnNullNode.patch
@@ -1,0 +1,36 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Fri Jun 26 13:44:42 2026
+Subject: QDom: Change default InvalidDataPolicy to ReturnNullNode
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/748323
+
+
+---
+Index: qt6-base/src/xml/dom/qdom.cpp
+===================================================================
+--- qt6-base.orig/src/xml/dom/qdom.cpp
++++ qt6-base/src/xml/dom/qdom.cpp
+@@ -91,7 +91,7 @@ static void qt_split_namespace(QString&
+  *
+  **************************************************************/
+ QDomImplementation::InvalidDataPolicy QDomImplementationPrivate::invalidDataPolicy
+-    = QDomImplementation::AcceptInvalidChars;
++    = QDomImplementation::ReturnNullNode;
+ 
+ // [5] Name ::= (Letter | '_' | ':') (NameChar)*
+ 
+@@ -541,11 +541,12 @@ bool QDomImplementation::isNull()
+     This enum specifies what should be done when a factory function
+     in QDomDocument is called with invalid data.
+     \value AcceptInvalidChars The data should be stored in the DOM object
+-        anyway. In this case the resulting XML document might not be well-formed.
+-        This is the default value and QDom's behavior in Qt < 4.1.
++           anyway. In this case the resulting XML document might not be well-formed.
++           This was the default value and QDom's behavior prior to Qt 6.12.
+     \value DropInvalidChars The invalid characters should be removed from
+-        the data.
++           the data.
+     \value ReturnNullNode The factory function should return a null node.
++           This is the default value since Qt 6.12.
+ 
+     \sa setInvalidDataPolicy(), invalidDataPolicy()
+ */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -44,3 +44,4 @@ fix-xcb-clear-stale-internal-state-when-setting-up-slave-devices.patch
 fix-xcb-Handle-DEVICE_ENABLED-in-XI2-hierarchy-events.patch
 fix-QLabel-Reset-link-hover-state.patch
 qt6-base-add-multi-seat-event.patch
+QDom-Change-default-InvalidDataPolicy-to-ReturnNullNode.patch


### PR DESCRIPTION
Change the default policy from AcceptInvalidChars to ReturnNullNode.

Log: Change the default QDom invalid data policy
