### PR TITLE
fix: QXmlStreamReader: fix quadratic behavior in resolveTag()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.8.0+dfsg-0deepin26) unstable; urgency=medium
+
+  * Update patch: fix quadratic behavior in resolveTag (CVE-2026-16762, QTBUG-147009).
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Tue, 28 Jul 2026 11:51:33 +0800
+
 qt6-base (6.8.0+dfsg-0deepin25) unstable; urgency=medium
 
   * Update patch: change QDom default InvalidDataPolicy to

--- a/debian/patches/CVE-2026-16762_fix-quadratic-behavior-in-resolvetag.patch
+++ b/debian/patches/CVE-2026-16762_fix-quadratic-behavior-in-resolvetag.patch
@@ -1,0 +1,168 @@
+Author: Tian Shilin <tianshilin@uniontech.com>
+Date:   Wed May 27 10:06:21 2026
+Subject: QXmlStreamReader: fix quadratic behavior in resolveTag()
+Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/738885
+
+
+---
+
+Index: qt6-base/src/corelib/serialization/qxmlstream.cpp
+===================================================================
+--- qt6-base.orig/src/corelib/serialization/qxmlstream.cpp
++++ qt6-base/src/corelib/serialization/qxmlstream.cpp
+@@ -14,7 +14,7 @@
+ #include <qbuffer.h>
+ #include <qscopeguard.h>
+ #include <qcoreapplication.h>
+-
++#include <QtCore/private/qduplicatetracker_p.h>
+ #include <private/qoffsetstringarray_p.h>
+ #include <private/qtools_p.h>
+ 
+@@ -1596,6 +1596,35 @@ XmlStringRef QXmlStreamReaderPrivate::na
+      return XmlStringRef();
+ }
+ 
++struct AttributeName
++{
++    QStringView name;
++    QStringView qualifiedName;
++    QStringView namespaceUri;
++
++    static AttributeName fromXmlAttribute(const QXmlStreamAttribute &a, bool nsProcessing)
++    {
++        if (nsProcessing)
++            return {a.name(), {}, a.namespaceUri()};
++        else
++            return {a.name(), a.qualifiedName(), a.namespaceUri()};
++    }
++
++    friend bool operator==(const AttributeName &lhs, const AttributeName &rhs) noexcept
++    {
++        return lhs.name == rhs.name
++            && lhs.qualifiedName == rhs.qualifiedName
++            && lhs.namespaceUri == rhs.namespaceUri;
++    }
++    friend size_t qHash(const AttributeName &key, size_t seed = 0) noexcept
++    {
++        return qHashMulti(seed,
++                          key.name,
++                          key.qualifiedName,
++                          key.namespaceUri);
++    }
++};
++
+ /*
+   uses namespaceForPrefix and builds the attribute vector
+  */
+@@ -1647,6 +1676,9 @@ void QXmlStreamReaderPrivate::resolveTag
+ 
+     attributes.resize(n);
+ 
++    Q_DECL_UNINITIALIZED
++    QDuplicateTracker<AttributeName, 13> names(n);
++
+     for (qsizetype i = 0; i < n; ++i) {
+         QXmlStreamAttribute &attribute = attributes[i];
+         Attribute &attrib = attributeStack[i];
+@@ -1664,14 +1696,9 @@ void QXmlStreamReaderPrivate::resolveTag
+             attribute.m_namespaceUri = XmlStringRef(attributeNamespaceUri);
+         }
+ 
+-        for (qsizetype j = 0; j < i; ++j) {
+-            if (attributes[j].name() == attribute.name()
+-                && attributes[j].namespaceUri() == attribute.namespaceUri()
+-                && (namespaceProcessing || attributes[j].qualifiedName() == attribute.qualifiedName()))
+-            {
+-                raiseWellFormedError(QXmlStream::tr("Attribute '%1' redefined.").arg(attribute.qualifiedName()));
+-                return;
+-            }
++        if (names.hasSeen(AttributeName::fromXmlAttribute(attribute, namespaceProcessing))) {
++            raiseWellFormedError(QXmlStream::tr("Attribute '%1' redefined.").arg(attribute.qualifiedName()));
++            return;
+         }
+     }
+ 
+Index: qt6-base/tests/auto/corelib/serialization/qxmlstream/tst_qxmlstream.cpp
+===================================================================
+--- qt6-base.orig/tests/auto/corelib/serialization/qxmlstream/tst_qxmlstream.cpp
++++ qt6-base/tests/auto/corelib/serialization/qxmlstream/tst_qxmlstream.cpp
+@@ -600,6 +600,7 @@ private slots:
+     void test_fastScanName() const;
+ 
+     void entityExpansionLimit() const;
++    void manyAttributes() const;
+ 
+     void tokenErrorHandling_data() const;
+     void tokenErrorHandling() const;
+@@ -2008,6 +2009,70 @@ void tst_QXmlStream::entityExpansionLimi
+     }
+ }
+ 
++constexpr const char L1NameStartCharsExCOLON[] = {
++    // https://www.w3.org/TR/REC-xml/#NT-NameStartChar - COLON - [#x100-#xEFFFF]:
++    // [A-Z]
++    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
++    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
++    // "_"
++    '_',
++    // [a-z]
++    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
++    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
++    // [#xC0-#xD6]
++    '\xC0', '\xC1', '\xC2', '\xC3', '\xC4', '\xC5', '\xC6', '\xC7',
++    '\xC8', '\xC9', '\xCA', '\xCB', '\xCC', '\xCD', '\xCE', '\xCF',
++    '\xD0', '\xD1', '\xD2', '\xD3', '\xD4', '\xD5', '\xD6',
++    // [#xD8-#xF6]
++    '\xD8', '\xD9', '\xDA', '\xDB', '\xDC', '\xDD', '\xDE', '\xDF',
++    '\xE0', '\xE1', '\xE2', '\xE3', '\xE4', '\xE5', '\xE6', '\xE7',
++    '\xE8', '\xE9', '\xEA', '\xEB', '\xEC', '\xED', '\xEE', '\xEF',
++    '\xF0', '\xF1', '\xF2', '\xF3', '\xF4', '\xF5', '\xF6',
++    // [#xF8-#x2FF] (truncated to L1 range)
++    '\xF8', '\xF9', '\xFA', '\xFB', '\xFC', '\xFD', '\xFE', '\xFF',
++};
++
++void tst_QXmlStream::manyAttributes() const
++{
++
++    constexpr qsizetype numDigits = sizeof L1NameStartCharsExCOLON;
++    static_assert(numDigits == 115); // FYI
++    constexpr auto numAttributes = numDigits * numDigits * numDigits;
++
++    constexpr auto opening = "<?xml version='1.0'?>\n"
++                             "<e"_L1;
++    constexpr auto closing = "></e>"_L1;
++    char attr[] = { ' ', 'a', 'b', 'c', '=', '"', '"' };
++
++    QString xml;
++    xml.reserve(opening.size() + closing.size() + numAttributes * sizeof attr);
++
++    xml += opening;
++    for (char i : L1NameStartCharsExCOLON) {
++        attr[1] = i;
++        for (char j : L1NameStartCharsExCOLON) {
++            attr[2] = j;
++            for (char k : L1NameStartCharsExCOLON) {
++                attr[3] = k;
++                xml += QLatin1StringView(attr, sizeof attr);
++            }
++        }
++    }
++    xml += closing;
++
++    QXmlStreamReader r(xml);
++    while (!r.atEnd()) {
++        r.readNext();
++        if (!r.isStartElement())
++            continue;
++        QCOMPARE(r.name(), "e"_L1);
++        const auto attrs = r.attributes();
++        QCOMPARE(attrs.size(), numAttributes);
++        return; // success
++    }
++    QFAIL("Did not find expected StartElement");
++}
++
+ void tst_QXmlStream::roundTrip() const
+ {
+     QFETCH(QString, in);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -45,3 +45,4 @@ fix-xcb-Handle-DEVICE_ENABLED-in-XI2-hierarchy-events.patch
 fix-QLabel-Reset-link-hover-state.patch
 qt6-base-add-multi-seat-event.patch
 QDom-Change-default-InvalidDataPolicy-to-ReturnNullNode.patch
+CVE-2026-16762_fix-quadratic-behavior-in-resolvetag.patch


### PR DESCRIPTION
Log: In resolveTag(), as part of the well-formed check, we search for potential duplicate attributes, by doing the equivalent of

  for (i = 0; i < c.size(); ++i)
      for (j = 0; j < i; ++j)
        if (c[i] == c[j]) return error;

This is quadratic. Since the number of attributes is externally-controlled, this is an easy CPU-hogging that can be used to DoS the application.

QXmlStream should have a user-configurable limit for the number of attributes on a single element, but as a hot-fix, remove the O(N²) behavior by using QDuplicateTracker.

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/738885
Bug: https://bugreports.qt.io/browse/QTBUG-147009