### PR TITLE
fix: CVE-2026-16762: QXmlStreamReader: fix quadratic behavior in reso…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-base (6.8.0+dfsg-0deepin27) unstable; urgency=medium
+
+  * fix quadratic behavior in resolveTag (CVE-2026-16762,update)
+
+ -- Tian ShiLin <tianshilin@uniontech.com >  Fri, 31 Jul 2026 14:27:11 +0800
+
 qt6-base (6.8.0+dfsg-0deepin26) unstable; urgency=medium
 
   * Update patch: fix quadratic behavior in resolveTag (CVE-2026-16762, QTBUG-147009).

--- a/debian/patches/CVE-2026-16762_fix-quadratic-behavior-in-resolvetag.patch
+++ b/debian/patches/CVE-2026-16762_fix-quadratic-behavior-in-resolvetag.patch
@@ -55,17 +55,16 @@ Index: qt6-base/src/corelib/serialization/qxmlstream.cpp
  /*
    uses namespaceForPrefix and builds the attribute vector
   */
-@@ -1647,6 +1676,9 @@ void QXmlStreamReaderPrivate::resolveTag
+@@ -1647,6 +1676,8 @@ void QXmlStreamReaderPrivate::resolveTag
  
      attributes.resize(n);
  
-+    Q_DECL_UNINITIALIZED
 +    QDuplicateTracker<AttributeName, 13> names(n);
 +
      for (qsizetype i = 0; i < n; ++i) {
          QXmlStreamAttribute &attribute = attributes[i];
          Attribute &attrib = attributeStack[i];
-@@ -1664,14 +1696,9 @@ void QXmlStreamReaderPrivate::resolveTag
+@@ -1664,14 +1695,9 @@ void QXmlStreamReaderPrivate::resolveTag
              attribute.m_namespaceUri = XmlStringRef(attributeNamespaceUri);
          }
  


### PR DESCRIPTION
log: optimization patch.

Upstream: https://codereview.qt-project.org/c/qt/qtbase/+/738885
Bug: https://bugreports.qt.io/browse/QTBUG-147009
CVE: CVE-2026-16762